### PR TITLE
Updating google/cloud to 0.*.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": "^7.0",
-    "google/cloud": "~0.65.0",
+    "google/cloud": "0.*.*",
     "darrynten/any-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": "^7.0",
-    "google/cloud": "^0.20.2",
+    "google/cloud": "^0.65.0",
     "darrynten/any-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": "^7.0",
-    "google/cloud": "^0.65.0",
+    "google/cloud": "~0.65.0",
     "darrynten/any-cache": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This should be backwards compatible, but allows this to be used alongside other libraries which need a newer version of `google/cloud`.

Thanks